### PR TITLE
fix: correct build failure detection on workflows

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,7 +12,9 @@ jobs:
           sudo apt update
           sudo apt install gcc-aarch64-linux-gnu device-tree-compiler gcc-arm-none-eabi
       - name: Build
-        id: build
+        # "shell: bash" implies "-o pipefail" -> pipelines fail if any part fails
+        # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+        shell: bash
         run: |
           # Store all output so we can publish build log too for
           # later inspection if needed. It's good for transparency too.

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Build
         env:
           RELEASE_VERSION: ${{ github.ref_name }}
+        # "shell: bash" implies "-o pipefail" -> pipelines fail if any part fails
+        # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+        shell: bash
         run: |
           # Store all output so we can publish build log too for
           # later inspection if needed. It's good for transparency too.


### PR DESCRIPTION
Using "shell: bash" implies "-o pipefail" which makes pipelines fail if any part of pipeline fails.

Also, removed unneeded id from PR workflow's build step.