### PR TITLE
Build improvements uboot 2022.10 and variants

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Install toolchains
         run: |
           sudo apt update
-          sudo apt install gcc-aarch64-linux-gnu device-tree-compiler gcc-arm-none-eabi
+          sudo apt install gcc-aarch64-linux-gnu device-tree-compiler gcc-arm-linux-gnueabihf gcc-arm-none-eabi
       - name: Build
         # "shell: bash" implies "-o pipefail" -> pipelines fail if any part fails
         # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install toolchains
         run: |
           sudo apt update
-          sudo apt install gcc-aarch64-linux-gnu device-tree-compiler gcc-arm-none-eabi
+          sudo apt install gcc-aarch64-linux-gnu device-tree-compiler gcc-arm-linux-gnueabihf gcc-arm-none-eabi
       - name: Build
         env:
           RELEASE_VERSION: ${{ github.ref_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+dl

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN set -ex \
         flex \
         gawk \
         gcc-aarch64-linux-gnu \
+        gcc-arm-linux-gnueabihf \
         gcc-arm-none-eabi \
         git \
         less \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN set -ex \
         python3 \
         python3-dev \
         python3-distutils \
+        python3-setuptools \
         python-pyelftools \
         rename \
         sed \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN set -ex \
         bison \
         build-essential \
         ca-certificates \
+        curl \
         device-tree-compiler \
         dosfstools \
         flex \

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ U-Boot and Arm Trusted Firmware have their own licences.
     - `UBOOT_VERSION` U-Boot version to build (use a tag)
     - `UBOOT_CONFIG` U-Boot defconfig (used in make)
     - `UBOOT_CROSS_COMPILE` U-Boot CROSS_COMPILE option (used in make)
+    - `UBOOT_USE_GIT` (`true` or `false`) Use Git to get U-Boot sources if `true`;
+      otherwise download sources with `curl`.
 - patch apply order: closest to root first in filename sort order.
 - directory structure in `boards` is expected to have `platform`/`board`
   as leaf directories (which may contain `atf-patches` and `uboot-patches`)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ U-Boot and Arm Trusted Firmware have their own licences.
     - `UBOOT_CONFIG` U-Boot defconfig (used in make)
     - `UBOOT_CROSS_COMPILE` U-Boot CROSS_COMPILE option (used in make)
     - `UBOOT_USE_GIT` (`true` or `false`) Use Git to get U-Boot sources if `true`;
-      otherwise download sources with `curl`.
+      otherwise download sources with `curl` (default: `false` -> use `curl`).
 - patch apply order: closest to root first in filename sort order.
 - directory structure in `boards` is expected to have `platform`/`board`
   as leaf directories (which may contain `atf-patches` and `uboot-patches`)

--- a/board/config
+++ b/board/config
@@ -3,3 +3,6 @@ ATF_VERSION=v2.7.0
 ATF_CROSS_COMPILE=aarch64-linux-gnu-
 UBOOT_VERSION=v2022.07
 UBOOT_CROSS_COMPILE=aarch64-linux-gnu-
+
+# Use Git for uboot (download source package otherwise)
+UBOOT_USE_GIT=false

--- a/board/config
+++ b/board/config
@@ -1,7 +1,7 @@
 # This is for all boards. Override in deeper configs.
 ATF_VERSION=v2.7.0
 ATF_CROSS_COMPILE=aarch64-linux-gnu-
-UBOOT_VERSION=v2022.07
+UBOOT_VERSION=v2022.10
 UBOOT_CROSS_COMPILE=aarch64-linux-gnu-
 
 # Use Git for uboot (download source package otherwise)

--- a/board/config
+++ b/board/config
@@ -3,6 +3,15 @@ ATF_VERSION=v2.7.0
 ATF_CROSS_COMPILE=aarch64-linux-gnu-
 UBOOT_VERSION=v2022.10
 UBOOT_CROSS_COMPILE=aarch64-linux-gnu-
+UBOOT_BL=BL31
+
+# Bash glob to get u-boot binaries
+UBOOT_BIN_GLOB="[iu]*.{img,bin,itb}"
 
 # Use Git for uboot (download source package otherwise)
 UBOOT_USE_GIT=false
+
+# Default make commands (used for the most of builds)
+ATF_MAKE='make "PLAT=${ATF_PLATFORM}" "CROSS_COMPILE=${ATF_CROSS_COMPILE}" -j$(nproc)'
+UBOOT_MAKE_CONFIG='make "${UBOOT_BL}=${!UBOOT_BL}" "CROSS_COMPILE=${UBOOT_CROSS_COMPILE}" "${UBOOT_CONFIG}"'
+UBOOT_MAKE_BIN='make "${UBOOT_BL}=${!UBOOT_BL}" "CROSS_COMPILE=${UBOOT_CROSS_COMPILE}" all -j$(nproc)'

--- a/board/rk3288/config
+++ b/board/rk3288/config
@@ -1,0 +1,13 @@
+# This is for all rk3288 boards. Override in deeper configs.
+ATF_PLATFORM=rk3288
+ATF_CROSS_COMPILE=arm-linux-gnueabihf-
+UBOOT_CROSS_COMPILE=arm-linux-gnueabihf-
+UBOOT_BL=BL32
+
+# Bash glob to get u-boot binaries
+UBOOT_BIN_GLOB="[iu]*.{img,bin}"
+
+# Make commands for rk3288 boards
+ATF_MAKE='make "PLAT=${ATF_PLATFORM}" "CROSS_COMPILE=${ATF_CROSS_COMPILE}" ARCH=aarch32 AARCH32_SP=sp_min -j$(nproc)'
+UBOOT_MAKE_CONFIG='make "${UBOOT_BL}=${!UBOOT_BL}" "CROSS_COMPILE=${UBOOT_CROSS_COMPILE}" "${UBOOT_CONFIG}"'
+UBOOT_MAKE_BIN='make "${UBOOT_BL}=${!UBOOT_BL}" "CROSS_COMPILE=${UBOOT_CROSS_COMPILE}" all -j$(nproc)'

--- a/board/rk3288/firefly/config
+++ b/board/rk3288/firefly/config
@@ -1,0 +1,1 @@
+UBOOT_CONFIG=firefly-rk3288_defconfig

--- a/board/rk3288/miqi/config
+++ b/board/rk3288/miqi/config
@@ -1,0 +1,1 @@
+UBOOT_CONFIG=miqi-rk3288_defconfig

--- a/board/rk3288/rel-note-extra.md
+++ b/board/rk3288/rel-note-extra.md
@@ -1,0 +1,2 @@
+  - "the default" U-Boot build for `rk3288` with following change:
+    - `CONFIG_PREBOOT=""` to NOT start usb on boot to make it boot faster (enumerating USB is _slow_)

--- a/board/rk3288/rock-pi-n8/config
+++ b/board/rk3288/rock-pi-n8/config
@@ -1,0 +1,1 @@
+UBOOT_CONFIG=rock-pi-n8-rk3288_defconfig

--- a/board/rk3288/tinker-s/config
+++ b/board/rk3288/tinker-s/config
@@ -1,0 +1,1 @@
+UBOOT_CONFIG=tinker-s-rk3288_defconfig

--- a/board/rk3288/uboot-patches/0001-rk3288-multiple-boards-no-preboot-command.patch
+++ b/board/rk3288/uboot-patches/0001-rk3288-multiple-boards-no-preboot-command.patch
@@ -1,0 +1,55 @@
+diff --git a/configs/firefly-rk3288_defconfig b/configs/firefly-rk3288_defconfig
+index 1349d6464d..45ac04463b 100644
+--- a/configs/firefly-rk3288_defconfig
++++ b/configs/firefly-rk3288_defconfig
+@@ -95,3 +95,6 @@ CONFIG_DISPLAY_ROCKCHIP_HDMI=y
+ CONFIG_CONSOLE_SCROLL_LINES=10
+ CONFIG_CMD_DHRYSTONE=y
+ CONFIG_ERRNO_STR=y
++# Faster boot w/o usb.
++# (Default is CONFIG_PREBOOT="usb start" when CONFIG_USB_KEYBOARD=y)
++CONFIG_PREBOOT=""
+diff --git a/configs/miqi-rk3288_defconfig b/configs/miqi-rk3288_defconfig
+index 75675e6095..9fd324acb4 100644
+--- a/configs/miqi-rk3288_defconfig
++++ b/configs/miqi-rk3288_defconfig
+@@ -92,3 +92,6 @@ CONFIG_DISPLAY_ROCKCHIP_HDMI=y
+ CONFIG_CONSOLE_SCROLL_LINES=10
+ CONFIG_CMD_DHRYSTONE=y
+ CONFIG_ERRNO_STR=y
++# Faster boot w/o usb.
++# (Default is CONFIG_PREBOOT="usb start" when CONFIG_USB_KEYBOARD=y)
++CONFIG_PREBOOT=""
+diff --git a/configs/rock-pi-n8-rk3288_defconfig b/configs/rock-pi-n8-rk3288_defconfig
+index 6227ad39c1..51fc676330 100644
+--- a/configs/rock-pi-n8-rk3288_defconfig
++++ b/configs/rock-pi-n8-rk3288_defconfig
+@@ -88,3 +88,6 @@ CONFIG_DISPLAY=y
+ CONFIG_VIDEO_ROCKCHIP=y
+ CONFIG_DISPLAY_ROCKCHIP_HDMI=y
+ CONFIG_ERRNO_STR=y
++# Faster boot w/o usb.
++# (Default is CONFIG_PREBOOT="usb start" when CONFIG_USB_KEYBOARD=y)
++CONFIG_PREBOOT=""
+diff --git a/configs/tinker-s-rk3288_defconfig b/configs/tinker-s-rk3288_defconfig
+index 28ae79bc01..b543023ad2 100644
+--- a/configs/tinker-s-rk3288_defconfig
++++ b/configs/tinker-s-rk3288_defconfig
+@@ -100,3 +100,6 @@ CONFIG_DISPLAY_ROCKCHIP_HDMI=y
+ CONFIG_CONSOLE_SCROLL_LINES=10
+ CONFIG_CMD_DHRYSTONE=y
+ CONFIG_ERRNO_STR=y
++# Faster boot w/o usb.
++# (Default is CONFIG_PREBOOT="usb start" when CONFIG_USB_KEYBOARD=y)
++CONFIG_PREBOOT=""
+diff --git a/configs/vyasa-rk3288_defconfig b/configs/vyasa-rk3288_defconfig
+index 4b5b1db0ff..9e064b2c64 100644
+--- a/configs/vyasa-rk3288_defconfig
++++ b/configs/vyasa-rk3288_defconfig
+@@ -101,3 +101,6 @@ CONFIG_DISPLAY_ROCKCHIP_HDMI=y
+ CONFIG_CONSOLE_SCROLL_LINES=10
+ CONFIG_CMD_DHRYSTONE=y
+ CONFIG_ERRNO_STR=y
++# Faster boot w/o usb.
++# (Default is CONFIG_PREBOOT="usb start" when CONFIG_USB_KEYBOARD=y)
++CONFIG_PREBOOT=""

--- a/board/rk3288/vyasa/config
+++ b/board/rk3288/vyasa/config
@@ -1,0 +1,1 @@
+UBOOT_CONFIG=vyasa-rk3288_defconfig

--- a/board/rk3328/roc-cc/config
+++ b/board/rk3328/roc-cc/config
@@ -1,0 +1,1 @@
+UBOOT_CONFIG=roc-cc-rk3328_defconfig

--- a/board/rk3328/rock-pi-e/config
+++ b/board/rk3328/rock-pi-e/config
@@ -1,0 +1,1 @@
+UBOOT_CONFIG=rock-pi-e-rk3328_defconfig

--- a/board/rk3399-emmc-1st/config
+++ b/board/rk3399-emmc-1st/config
@@ -1,0 +1,2 @@
+# This is for all rk3399 boards. Override in deeper configs.
+ATF_PLATFORM=rk3399

--- a/board/rk3399-emmc-1st/rel-note-extra.md
+++ b/board/rk3399-emmc-1st/rel-note-extra.md
@@ -1,7 +1,5 @@
   - "the eMMC 1st" U-Boot build for `rk3399` with following changes:
     - `CONFIG_BOOTDELAY=0` to make it boot faster
-    - `CONFIG_PREBOOT=""` to NOT start usb on boot to make it boot faster
-      (enumerating USB is _slow_)
+    - `CONFIG_PREBOOT=""` to NOT start usb on boot to make it boot faster (enumerating USB is _slow_)
     - boot order is changed to: 1) eMMC, 2) SD card
-  - only building rockpro64 (at least for now),
-    it's for my (nuumio's) special retrogaming rockpro64 setup
+  - only building rockpro64 (at least for now), it's for my (nuumio's) special retrogaming rockpro64 setup

--- a/board/rk3399-emmc-1st/rel-note-extra.md
+++ b/board/rk3399-emmc-1st/rel-note-extra.md
@@ -1,0 +1,7 @@
+  - "the eMMC 1st" U-Boot build for `rk3399` with following changes:
+    - `CONFIG_BOOTDELAY=0` to make it boot faster
+    - `CONFIG_PREBOOT=""` to NOT start usb on boot to make it boot faster
+      (enumerating USB is _slow_)
+    - boot order is changed to: 1) eMMC, 2) SD card
+  - only building rockpro64 (at least for now),
+    it's for my (nuumio's) special retrogaming rockpro64 setup

--- a/board/rk3399-emmc-1st/rockpro64/config
+++ b/board/rk3399-emmc-1st/rockpro64/config
@@ -1,0 +1,1 @@
+UBOOT_CONFIG=rockpro64-rk3399_defconfig

--- a/board/rk3399-emmc-1st/uboot-patches/0001-rk3399-multiple-boards-no-boot-delay-no-preboot-command.patch
+++ b/board/rk3399-emmc-1st/uboot-patches/0001-rk3399-multiple-boards-no-boot-delay-no-preboot-command.patch
@@ -1,0 +1,78 @@
+diff --git a/configs/orangepi-rk3399_defconfig b/configs/orangepi-rk3399_defconfig
+index fa117ba8d1..fb6a353d18 100644
+--- a/configs/orangepi-rk3399_defconfig
++++ b/configs/orangepi-rk3399_defconfig
+@@ -65,3 +65,5 @@ CONFIG_USB_ETHER_RTL8152=y
+ CONFIG_USB_ETHER_SMSC95XX=y
+ CONFIG_SPL_TINY_MEMSET=y
+ CONFIG_ERRNO_STR=y
++# Faster boot w/o delay
++CONFIG_BOOTDELAY=0
+diff --git a/configs/pinebook-pro-rk3399_defconfig b/configs/pinebook-pro-rk3399_defconfig
+index 5d9a841899..21eb4d4d15 100644
+--- a/configs/pinebook-pro-rk3399_defconfig
++++ b/configs/pinebook-pro-rk3399_defconfig
+@@ -17,7 +17,6 @@ CONFIG_SYS_LOAD_ADDR=0x800800
+ CONFIG_DEBUG_UART=y
+ CONFIG_HAS_CUSTOM_SYS_INIT_SP_ADDR=y
+ CONFIG_CUSTOM_SYS_INIT_SP_ADDR=0x300000
+-CONFIG_BOOTDELAY=3
+ CONFIG_USE_PREBOOT=y
+ CONFIG_DEFAULT_FDT_FILE="rockchip/rk3399-pinebook-pro.dtb"
+ CONFIG_DISPLAY_BOARDINFO_LATE=y
+@@ -103,3 +102,7 @@ CONFIG_VIDEO_ROCKCHIP=y
+ CONFIG_DISPLAY_ROCKCHIP_EDP=y
+ CONFIG_SPL_TINY_MEMSET=y
+ CONFIG_ERRNO_STR=y
++# Faster boot w/o delay and usb.
++# (Default is CONFIG_PREBOOT="usb start" when CONFIG_USB_KEYBOARD=y)
++CONFIG_BOOTDELAY=0
++CONFIG_PREBOOT=""
+diff --git a/configs/rock-pi-4-rk3399_defconfig b/configs/rock-pi-4-rk3399_defconfig
+index f8a57f6838..19cf555d12 100644
+--- a/configs/rock-pi-4-rk3399_defconfig
++++ b/configs/rock-pi-4-rk3399_defconfig
+@@ -84,3 +84,7 @@ CONFIG_VIDEO_ROCKCHIP=y
+ CONFIG_DISPLAY_ROCKCHIP_HDMI=y
+ CONFIG_SPL_TINY_MEMSET=y
+ CONFIG_ERRNO_STR=y
++# Faster boot w/o delay and usb.
++# (Default is CONFIG_PREBOOT="usb start" when CONFIG_USB_KEYBOARD=y)
++CONFIG_BOOTDELAY=0
++CONFIG_PREBOOT=""
+diff --git a/configs/rock-pi-4c-rk3399_defconfig b/configs/rock-pi-4c-rk3399_defconfig
+index 9aa7809bd0..ecd42154dd 100644
+--- a/configs/rock-pi-4c-rk3399_defconfig
++++ b/configs/rock-pi-4c-rk3399_defconfig
+@@ -84,3 +84,7 @@ CONFIG_VIDEO_ROCKCHIP=y
+ CONFIG_DISPLAY_ROCKCHIP_HDMI=y
+ CONFIG_SPL_TINY_MEMSET=y
+ CONFIG_ERRNO_STR=y
++# Faster boot w/o delay and usb.
++# (Default is CONFIG_PREBOOT="usb start" when CONFIG_USB_KEYBOARD=y)
++CONFIG_BOOTDELAY=0
++CONFIG_PREBOOT=""
+diff --git a/configs/rock960-rk3399_defconfig b/configs/rock960-rk3399_defconfig
+index daa0d3ddf5..66c189e55d 100644
+--- a/configs/rock960-rk3399_defconfig
++++ b/configs/rock960-rk3399_defconfig
+@@ -88,3 +88,7 @@ CONFIG_VIDEO_ROCKCHIP=y
+ CONFIG_DISPLAY_ROCKCHIP_HDMI=y
+ CONFIG_SPL_TINY_MEMSET=y
+ CONFIG_ERRNO_STR=y
++# Faster boot w/o delay and usb.
++# (Default is CONFIG_PREBOOT="usb start" when CONFIG_USB_KEYBOARD=y)
++CONFIG_BOOTDELAY=0
++CONFIG_PREBOOT=""
+diff --git a/configs/rockpro64-rk3399_defconfig b/configs/rockpro64-rk3399_defconfig
+index 87fe8c4046..6d415f56cc 100644
+--- a/configs/rockpro64-rk3399_defconfig
++++ b/configs/rockpro64-rk3399_defconfig
+@@ -104,3 +104,7 @@ CONFIG_VIDEO_ROCKCHIP=y
+ CONFIG_DISPLAY_ROCKCHIP_HDMI=y
+ CONFIG_SPL_TINY_MEMSET=y
+ CONFIG_ERRNO_STR=y
++# Faster boot w/o delay and usb.
++# (Default is CONFIG_PREBOOT="usb start" when CONFIG_USB_KEYBOARD=y)
++CONFIG_BOOTDELAY=0
++CONFIG_PREBOOT=""

--- a/board/rk3399-emmc-1st/uboot-patches/0002-rk3399-emmc-before-sd-card.patch
+++ b/board/rk3399-emmc-1st/uboot-patches/0002-rk3399-emmc-before-sd-card.patch
@@ -1,0 +1,19 @@
+diff --git a/include/configs/rockchip-common.h b/include/configs/rockchip-common.h
+index 4c964cc377..49d8e378d1 100644
+--- a/include/configs/rockchip-common.h
++++ b/include/configs/rockchip-common.h
+@@ -13,11 +13,11 @@
+ 
+ #ifndef CONFIG_SPL_BUILD
+ 
+-/* First try to boot from SD (index 1), then eMMC (index 0) */
++/* First try to boot from eMMC (index 0), then SD (index 1) */
+ #if CONFIG_IS_ENABLED(CMD_MMC)
+ 	#define BOOT_TARGET_MMC(func) \
+-		func(MMC, mmc, 1) \
+-		func(MMC, mmc, 0)
++		func(MMC, mmc, 0) \
++		func(MMC, mmc, 1)
+ #else
+ 	#define BOOT_TARGET_MMC(func)
+ #endif

--- a/board/rk3399/rel-note-extra.md
+++ b/board/rk3399/rel-note-extra.md
@@ -1,4 +1,3 @@
   - "the default" U-Boot build for `rk3399` with following changes:
     - `CONFIG_BOOTDELAY=0` to make it boot faster
-    - `CONFIG_PREBOOT=""` to NOT start usb on boot to make it boot faster
-      (enumerating USB is _slow_)
+    - `CONFIG_PREBOOT=""` to NOT start usb on boot to make it boot faster (enumerating USB is _slow_)

--- a/board/rk3399/rel-note-extra.md
+++ b/board/rk3399/rel-note-extra.md
@@ -1,0 +1,4 @@
+  - "the default" U-Boot build for `rk3399` with following changes:
+    - `CONFIG_BOOTDELAY=0` to make it boot faster
+    - `CONFIG_PREBOOT=""` to NOT start usb on boot to make it boot faster
+      (enumerating USB is _slow_)

--- a/board/rk3399/uboot-patches/0001-rk3399-multiple-boards-no-boot-delay-no-preboot-command.patch
+++ b/board/rk3399/uboot-patches/0001-rk3399-multiple-boards-no-boot-delay-no-preboot-command.patch
@@ -1,31 +1,38 @@
 diff --git a/configs/orangepi-rk3399_defconfig b/configs/orangepi-rk3399_defconfig
-index 461300fd10..4ef651fda0 100644
+index fa117ba8d1..fb6a353d18 100644
 --- a/configs/orangepi-rk3399_defconfig
 +++ b/configs/orangepi-rk3399_defconfig
-@@ -57,3 +57,5 @@ CONFIG_USB_ETHER_RTL8152=y
+@@ -65,3 +65,5 @@ CONFIG_USB_ETHER_RTL8152=y
  CONFIG_USB_ETHER_SMSC95XX=y
  CONFIG_SPL_TINY_MEMSET=y
  CONFIG_ERRNO_STR=y
 +# Faster boot w/o delay
 +CONFIG_BOOTDELAY=0
 diff --git a/configs/pinebook-pro-rk3399_defconfig b/configs/pinebook-pro-rk3399_defconfig
-index aaa52c6ea7..6290b4d614 100644
+index 5d9a841899..21eb4d4d15 100644
 --- a/configs/pinebook-pro-rk3399_defconfig
 +++ b/configs/pinebook-pro-rk3399_defconfig
-@@ -15,7 +15,7 @@ CONFIG_SPL_SPI_FLASH_SUPPORT=y
- CONFIG_SPL_SPI=y
- CONFIG_SYS_LOAD_ADDR=0x800800
+@@ -17,7 +17,6 @@ CONFIG_SYS_LOAD_ADDR=0x800800
  CONFIG_DEBUG_UART=y
+ CONFIG_HAS_CUSTOM_SYS_INIT_SP_ADDR=y
+ CONFIG_CUSTOM_SYS_INIT_SP_ADDR=0x300000
 -CONFIG_BOOTDELAY=3
-+CONFIG_BOOTDELAY=0
  CONFIG_USE_PREBOOT=y
  CONFIG_DEFAULT_FDT_FILE="rockchip/rk3399-pinebook-pro.dtb"
  CONFIG_DISPLAY_BOARDINFO_LATE=y
+@@ -103,3 +102,7 @@ CONFIG_VIDEO_ROCKCHIP=y
+ CONFIG_DISPLAY_ROCKCHIP_EDP=y
+ CONFIG_SPL_TINY_MEMSET=y
+ CONFIG_ERRNO_STR=y
++# Faster boot w/o delay and usb.
++# (Default is CONFIG_PREBOOT="usb start" when CONFIG_USB_KEYBOARD=y)
++CONFIG_BOOTDELAY=0
++CONFIG_PREBOOT=""
 diff --git a/configs/rock-pi-4-rk3399_defconfig b/configs/rock-pi-4-rk3399_defconfig
-index 80d1e63b59..5685a65dce 100644
+index f8a57f6838..19cf555d12 100644
 --- a/configs/rock-pi-4-rk3399_defconfig
 +++ b/configs/rock-pi-4-rk3399_defconfig
-@@ -76,3 +76,7 @@ CONFIG_VIDEO_ROCKCHIP=y
+@@ -84,3 +84,7 @@ CONFIG_VIDEO_ROCKCHIP=y
  CONFIG_DISPLAY_ROCKCHIP_HDMI=y
  CONFIG_SPL_TINY_MEMSET=y
  CONFIG_ERRNO_STR=y
@@ -34,10 +41,10 @@ index 80d1e63b59..5685a65dce 100644
 +CONFIG_BOOTDELAY=0
 +CONFIG_PREBOOT=""
 diff --git a/configs/rock-pi-4c-rk3399_defconfig b/configs/rock-pi-4c-rk3399_defconfig
-index bda4b70dbf..03b6ed33d4 100644
+index 9aa7809bd0..ecd42154dd 100644
 --- a/configs/rock-pi-4c-rk3399_defconfig
 +++ b/configs/rock-pi-4c-rk3399_defconfig
-@@ -76,3 +76,7 @@ CONFIG_VIDEO_ROCKCHIP=y
+@@ -84,3 +84,7 @@ CONFIG_VIDEO_ROCKCHIP=y
  CONFIG_DISPLAY_ROCKCHIP_HDMI=y
  CONFIG_SPL_TINY_MEMSET=y
  CONFIG_ERRNO_STR=y
@@ -46,10 +53,10 @@ index bda4b70dbf..03b6ed33d4 100644
 +CONFIG_BOOTDELAY=0
 +CONFIG_PREBOOT=""
 diff --git a/configs/rock960-rk3399_defconfig b/configs/rock960-rk3399_defconfig
-index be0e1c7d18..720b5c685f 100644
+index daa0d3ddf5..66c189e55d 100644
 --- a/configs/rock960-rk3399_defconfig
 +++ b/configs/rock960-rk3399_defconfig
-@@ -78,3 +78,7 @@ CONFIG_VIDEO_ROCKCHIP=y
+@@ -88,3 +88,7 @@ CONFIG_VIDEO_ROCKCHIP=y
  CONFIG_DISPLAY_ROCKCHIP_HDMI=y
  CONFIG_SPL_TINY_MEMSET=y
  CONFIG_ERRNO_STR=y
@@ -58,10 +65,10 @@ index be0e1c7d18..720b5c685f 100644
 +CONFIG_BOOTDELAY=0
 +CONFIG_PREBOOT=""
 diff --git a/configs/rockpro64-rk3399_defconfig b/configs/rockpro64-rk3399_defconfig
-index b0c3527fab..a49801a5f2 100644
+index 87fe8c4046..6d415f56cc 100644
 --- a/configs/rockpro64-rk3399_defconfig
 +++ b/configs/rockpro64-rk3399_defconfig
-@@ -95,3 +95,7 @@ CONFIG_VIDEO_ROCKCHIP=y
+@@ -104,3 +104,7 @@ CONFIG_VIDEO_ROCKCHIP=y
  CONFIG_DISPLAY_ROCKCHIP_HDMI=y
  CONFIG_SPL_TINY_MEMSET=y
  CONFIG_ERRNO_STR=y

--- a/uboot-builder.sh
+++ b/uboot-builder.sh
@@ -116,8 +116,6 @@ build() {
   done
   echo -e "\n========================================\n"
 
-  return 0;
-
   # Build ATF
   cd "${CUR_DIR}/${BUILD_DIR}"
   git-update ATF "${ATF_REPO}" "${ATF_VERSION}" "${ATF_DIR}" || return 1
@@ -184,6 +182,8 @@ for conf in $(find board -mindepth 3 -type f -name config | sort); do
   unset UBOOT_CROSS_COMPILE
   unset PLAT_ATF_VERSION
   unset PLAT_UBOOT_VERSION
+  unset PLAT_NOTE_EXTRA
+  unset BOARD_NOTE_EXTRA
   UBOOT_USE_GIT=false
   ATF_PATCHES=()
   UBOOT_PATCHES=()
@@ -220,6 +220,14 @@ for conf in $(find board -mindepth 3 -type f -name config | sort); do
       # platform level
       PLAT_ATF_VERSION="${ATF_VERSION}"
       PLAT_UBOOT_VERSION="${UBOOT_VERSION}"
+      if [ -f "${confd}/rel-note-extra.md" ]; then
+        PLAT_NOTE_EXTRA="$(cat "${confd}/rel-note-extra.md")"
+      fi
+    fi
+    if [ "${I}" -eq 3 ]; then
+      if [ -f "${confd}/rel-note-extra.md" ]; then
+        BOARD_NOTE_EXTRA="$(cat "${confd}/rel-note-extra.md")"
+      fi
     fi
   done
 
@@ -248,6 +256,9 @@ for conf in $(find board -mindepth 3 -type f -name config | sort); do
     if [ "${PLAT_UBOOT_VERSION}" != "${DEFAULT_UBOOT_VERSION}" ]; then
       echo "  - ATF version: \`${PLAT_UBOOT_VERSION}\`" >> ${REL_NOTE}
     fi
+    if [ ! -z "${PLAT_NOTE_EXTRA}" ]; then
+      echo "${PLAT_NOTE_EXTRA}" >> ${REL_NOTE}
+    fi
     echo "  - board(s):" >> ${REL_NOTE}
   fi
   echo "    - \`${TARGET_BOARD}\`" >> ${REL_NOTE}
@@ -256,6 +267,9 @@ for conf in $(find board -mindepth 3 -type f -name config | sort); do
   fi
   if [ "${UBOOT_VERSION}" != "${PLAT_UBOOT_VERSION}" ]; then
     echo "      - U-Boot version: \`${UBOOT_VERSION}\`" >> ${REL_NOTE}
+  fi
+  if [ ! -z "${BOARD_NOTE_EXTRA}" ]; then
+    echo "${BOARD_NOTE_EXTRA}" >> ${REL_NOTE}
   fi
 done
 

--- a/uboot-builder.sh
+++ b/uboot-builder.sh
@@ -151,6 +151,9 @@ build() {
 # Prep build dir
 mkdir -p "${CUR_DIR}/${BUILD_DIR}"
 
+# Clean status, release note and comment every time
+rm -rf "${STATUS_FILE}" "${REL_NOTE}" "${COMMENT_FILE}"
+
 # Release header. Print default ATF and U-Boot versions if found (should be found).
 echo -e "Default ATF and U-Boot versions (platforms/boards use these unless otherwise noted):\n" >> ${REL_NOTE}
 . board/config
@@ -300,4 +303,6 @@ if [ "${FAILS}" -gt 0 ]; then
 else
   echo -e "# BUILD SUCCESS 🥳\n" >> "${COMMENT_FILE}"
   cat "${STATUS_FILE}" >> "${COMMENT_FILE}"
+  echo -e "\n# Release note "preview":\n" >> "${COMMENT_FILE}"
+  cat "${REL_NOTE}" >> "${COMMENT_FILE}"
 fi

--- a/uboot-builder.sh
+++ b/uboot-builder.sh
@@ -309,7 +309,7 @@ if [ ! -z "${RELEASE_VERSION}" ]; then
   echo -e "\n**sha256sums:**\n\n\`\`\`" >> ${REL_NOTE}
   cd "${CUR_DIR}/${BUILD_DIR}"
   # Pack by platform name
-  for p in $(find "${BINARIES_DIR}" -mindepth 1 -maxdepth 1 -type d); do
+  for p in $(find "${BINARIES_DIR}" -mindepth 1 -maxdepth 1 -type d | sort); do
     PLATFORM="$(basename "${p}")"
     PKG="u-boot-${PLATFORM}-${RELEASE_VERSION}.tar.gz"
     tar czf "${PKG}" -C "${BINARIES_DIR}" "${PLATFORM}"


### PR DESCRIPTION
- [x] some build improvements
- [x] bump uboot to 2022.10
- [x] adding "boot from emmc 1st"  `rk3399` "variant" (want that for myself)
- [x] more `rk3328` boards (want: `nanopi-r2s`, `roc-cc`, `rock64`, `rock-pi-e`)
- [ ] add `rk3288` boards (want: `firefly`, `miqi`, `rock-pi-n8`, `tinker-s`, `vyasa` )