### PR TITLE
Fix miqi u-boot

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,14 +3,20 @@ on: [pull_request]
 jobs:
   build:
     name: Build U-Boot
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install toolchains
         run: |
           sudo apt update
-          sudo apt install gcc-aarch64-linux-gnu device-tree-compiler gcc-arm-linux-gnueabihf gcc-arm-none-eabi
+          sudo apt install \
+            device-tree-compiler \
+            gcc-10-aarch64-linux-gnu \
+            gcc-10-arm-linux-gnueabihf \
+            gcc-aarch64-linux-gnu \
+            gcc-arm-linux-gnueabihf \
+            gcc-arm-none-eabi
       - name: Build
         # "shell: bash" implies "-o pipefail" -> pipelines fail if any part fails
         # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
@@ -18,8 +24,14 @@ jobs:
         run: |
           # Store all output so we can publish build log too for
           # later inspection if needed. It's good for transparency too.
+          # Also, dump gcc versions to log too.
           mkdir -p build
-          ./uboot-builder.sh 2>&1 | tee build/build.log
+          (for cc in $(find /usr/bin/ -regextype posix-extended  -regex ".*gcc(-[0-9\.]+)?" | sort); \
+            do echo -e "$ ${cc}\n$($cc --version)\n"; \
+            done \
+          ) | tee build/build.log
+          mkdir -p build
+          ./uboot-builder.sh 2>&1 | tee -a build/build.log
       - name: Archive artifacts
         # Archive what ever we have even after failed build
         if: ${{ always() }}

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -6,14 +6,20 @@ on:
 jobs:
   build:
     name: Build U-Boot
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install toolchains
         run: |
           sudo apt update
-          sudo apt install gcc-aarch64-linux-gnu device-tree-compiler gcc-arm-linux-gnueabihf gcc-arm-none-eabi
+          sudo apt install \
+            device-tree-compiler \
+            gcc-10-aarch64-linux-gnu \
+            gcc-10-arm-linux-gnueabihf \
+            gcc-aarch64-linux-gnu \
+            gcc-arm-linux-gnueabihf \
+            gcc-arm-none-eabi
       - name: Build
         env:
           RELEASE_VERSION: ${{ github.ref_name }}
@@ -23,8 +29,13 @@ jobs:
         run: |
           # Store all output so we can publish build log too for
           # later inspection if needed. It's good for transparency too.
+          # Also, dump gcc versions to log too.
           mkdir -p build
-          ./uboot-builder.sh 2>&1 | tee build/build.log
+          (for cc in $(find /usr/bin/ -regextype posix-extended  -regex ".*gcc(-[0-9\.]+)?" | sort); \
+            do echo -e "$ ${cc}\n$($cc --version)\n"; \
+            done \
+          ) | tee build/build.log
+          ./uboot-builder.sh 2>&1 | tee -a build/build.log
       - name: Release
         uses: softprops/action-gh-release@v1
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND 'noninteractive'
 ENV XZ_DEFAULTS '-T0'
@@ -19,6 +19,8 @@ RUN set -ex \
         dosfstools \
         flex \
         gawk \
+        gcc-10-aarch64-linux-gnu \
+        gcc-10-arm-linux-gnueabihf \
         gcc-aarch64-linux-gnu \
         gcc-arm-linux-gnueabihf \
         gcc-arm-none-eabi \
@@ -30,12 +32,12 @@ RUN set -ex \
         locales \
         mtools \
         nano \
-        python \
+        python2 \
         python3 \
         python3-dev \
         python3-distutils \
         python3-setuptools \
-        python-pyelftools \
+        python3-pyelftools \
         rename \
         sed \
         swig \

--- a/board/rk3288/config
+++ b/board/rk3288/config
@@ -8,6 +8,7 @@ UBOOT_BL=BL32
 UBOOT_BIN_GLOB="[iu]*.{img,bin}"
 
 # Make commands for rk3288 boards
-ATF_MAKE='make "PLAT=${ATF_PLATFORM}" "CROSS_COMPILE=${ATF_CROSS_COMPILE}" ARCH=aarch32 AARCH32_SP=sp_min -j$(nproc)'
+# rk3288 TF-A build fails on gcc-11 so use gcc-19
+ATF_MAKE='make AR=arm-linux-gnueabihf-gcc-ar-10 AS=arm-linux-gnueabihf-gcc-10 CC=arm-linux-gnueabihf-gcc-10 "PLAT=${ATF_PLATFORM}" "CROSS_COMPILE=${ATF_CROSS_COMPILE}" ARCH=aarch32 AARCH32_SP=sp_min -j$(nproc)'
 UBOOT_MAKE_CONFIG='make "${UBOOT_BL}=${!UBOOT_BL}" "CROSS_COMPILE=${UBOOT_CROSS_COMPILE}" "${UBOOT_CONFIG}"'
 UBOOT_MAKE_BIN='make "${UBOOT_BL}=${!UBOOT_BL}" "CROSS_COMPILE=${UBOOT_CROSS_COMPILE}" all -j$(nproc)'

--- a/board/rk3288/miqi/config
+++ b/board/rk3288/miqi/config
@@ -1,1 +1,2 @@
 UBOOT_CONFIG=miqi-rk3288_defconfig
+UBOOT_MKIMAGE='./tools/mkimage -n rk3288 -T rksd -d spl/u-boot-spl-dtb.bin u-boot-with-spl.img && cat u-boot-dtb.bin >> u-boot-with-spl.img'

--- a/board/rk3288/miqi/uboot-patches/0001-MiQi-uboot-fixes.patch
+++ b/board/rk3288/miqi/uboot-patches/0001-MiQi-uboot-fixes.patch
@@ -1,0 +1,47 @@
+From 98664da52248aad2bb39177f8b5d5d4286f8e88f Mon Sep 17 00:00:00 2001
+From: Demetris Ierokipides <ierokipides.dem@gmail.com>
+Date: Mon, 10 Oct 2022 23:15:12 +0300
+Subject: [PATCH] MiQi uboot fixes
+
+---
+ arch/arm/dts/rk3288-miqi-u-boot.dtsi | 5 +++++
+ include/configs/miqi_rk3288.h        | 9 +++++++++
+ 2 files changed, 14 insertions(+)
+
+diff --git a/arch/arm/dts/rk3288-miqi-u-boot.dtsi b/arch/arm/dts/rk3288-miqi-u-boot.dtsi
+index 2a74fdd15f..e04ab12cac 100644
+--- a/arch/arm/dts/rk3288-miqi-u-boot.dtsi
++++ b/arch/arm/dts/rk3288-miqi-u-boot.dtsi
+@@ -5,6 +5,11 @@
+ 
+ #include "rk3288-u-boot.dtsi"
+ / {
++	chosen {
++		u-boot,spl-boot-order = \
++			"same-as-spl", &sdmmc, &emmc;
++	};
++
+ 	leds {
+ 		u-boot,dm-pre-reloc;
+ 
+diff --git a/include/configs/miqi_rk3288.h b/include/configs/miqi_rk3288.h
+index 053c9032e2..269ec529a3 100644
+--- a/include/configs/miqi_rk3288.h
++++ b/include/configs/miqi_rk3288.h
+@@ -13,4 +13,13 @@
+ 
+ #include <configs/rk3288_common.h>
+ 
++#undef BOOT_TARGET_DEVICES
++
++#define BOOT_TARGET_DEVICES(func) \
++	func(MMC, mmc, 0) \
++	func(MMC, mmc, 1) \
++	func(USB, usb, 0) \
++	func(PXE, pxe, na) \
++	func(DHCP, dchp, na)
++
+ #endif
+-- 
+2.34.1
+

--- a/uboot-builder.sh
+++ b/uboot-builder.sh
@@ -111,6 +111,9 @@ build() {
   echo "  UBOOT_BIN_GLOB: ${UBOOT_BIN_GLOB}"
   echo "  UBOOT_MAKE_CONFIG: ${UBOOT_MAKE_CONFIG}"
   echo "  UBOOT_MAKE_BIN: ${UBOOT_MAKE_BIN}"
+  if [ ! -z "${UBOOT_MKIMAGE}" ]; then
+    echo "  UBOOT_MKIMAGE: ${UBOOT_MKIMAGE}"
+  fi
   echo "  UBOOT_PATCHES:"
   for i in "${UBOOT_PATCHES[@]}"; do
     echo "    $i"
@@ -162,6 +165,10 @@ build() {
   eval "${UBOOT_MAKE_CONFIG}" || return 1
   echo "$(eval "echo + ${UBOOT_MAKE_BIN}")"
   eval "${UBOOT_MAKE_BIN}" || return 1
+  if [ ! -z "${UBOOT_MKIMAGE}" ]; then
+    echo "$(eval "echo + ${UBOOT_MKIMAGE}")"
+    eval "${UBOOT_MKIMAGE}" || return 1
+  fi
   eval "cp ${UBOOT_BIN_GLOB} "${BIN_TARGET}/"" || return 1
 }
 
@@ -209,6 +216,7 @@ for dplat in $(find board -mindepth 1 -maxdepth 1 -type d | sort); do
     unset UBOOT_BIN_GLOB
     unset UBOOT_MAKE_CONFIG
     unset UBOOT_MAKE_BIN
+    unset UBOOT_MKIMAGE
     unset PLAT_ATF_VERSION
     unset PLAT_UBOOT_VERSION
     unset PLAT_NOTE_EXTRA


### PR DESCRIPTION
3 things found about miqi u-boot and TF-A:
- u-boot image needs to be created with:

    ```
    ./tools/mkimage -n rk3288 -T rksd -d spl/u-boot-spl-dtb.bin uboot-miqi.img \
      && cat u-boot-dtb.bin >> uboot-miqi.img
    ```
- gcc-9 (`gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0`) fails to build working `u-boot-dtb.bin`
- gcc-11 fails to build TF-A for rk3288 (`make ARCH=aarch32 CROSS_COMPILE=arm-linux-gnueabihf- PLAT=rk3288 AARCH32_SP=sp_min`)

Failed TF-A build error for reference:

```
bl32/sp_min/aarch32/entrypoint.S: Assembler messages:
bl32/sp_min/aarch32/entrypoint.S:86: Error: selected processor does not support `vmsr FPEXC,r0' in ARM mode
bl32/sp_min/aarch32/entrypoint.S:307: Error: selected processor does not support `vmsr FPEXC,r0' in ARM mode
make: *** [Makefile:1322: /home/nuumio/src/batocera/u-boot-builder/build/atf/build/rk3288/release/bl32/entrypoint.o] Error 1
```

Solution:
- do the `mkimage` step for miqi
- use gcc-10 to build `rk3288` TF-A